### PR TITLE
Replace broken heuristics

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,7 @@
 MIT License
 
 Copyright (c) 2024 epCode
+Copyright (c) 2024 Kimapr
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/init.lua
+++ b/init.lua
@@ -1,55 +1,21 @@
-
-local INVLENGTH = 8
-local INVHEIGHT = 4
-
-local games = {
-  minetest = {8,4},
-  MineClone2 = {9,4},
-  exile = {8,2}
-}
-
-local id = "minetest"
-
-if minetest.get_modpath("mcl_core") then
-  id = "MineClone2"
-elseif minetest.get_modpath("exile_env_sounds") then
-  id = "exile"
-end
-
-if games[id] then
-
-  INVLENGTH = games[id][1]
-  INVHEIGHT = games[id][2]
-end
-
-
-local inv_size = INVLENGTH*INVHEIGHT
-
 controls.register_on_press(function(player, key)
-
   local ctrl = player:get_player_control()
-  if key == "aux1" and ctrl.sneak then
-  else
+  if not (key == "aux1" and ctrl.sneak) then
     return
   end
 
-
-  local inv = player:get_inventory():get_list("main")
-  local inv2 = {}
-
-  for i=1, inv_size+INVLENGTH do
-    inv2[i] = ""
+  local inv = player:get_inventory()
+  local width = inv:get_width("main")
+  if width == 0 then
+    width = 8
   end
-  for i,val in pairs(inv) do
-    inv2[i+INVLENGTH] = val
-  end
+  local list = inv:get_list("main")
+  local newlist = {}
+  local total = math.floor(#list / width) * width
 
-  for i,val in pairs(inv2) do
-    if i > inv_size then
-      inv2[i-inv_size] = val
-    end
+  for k, v in ipairs(list) do
+    newlist[k] = k <= total and list[(k - width -1) % total +1] or v
   end
 
-  player:get_inventory():set_list("main", inv2)
-
+  inv:set_list("main", newlist)
 end)

--- a/mod.conf
+++ b/mod.conf
@@ -1,4 +1,4 @@
 name = inv_cycle
-description = With sneak+zoom or sneak+use, the rows in your inventory will cycle. WARNING: if used on an unsupported game, your inventory may break!
+description = With sneak+zoom or sneak+use, the rows in your inventory will cycle.
 depends = controls
 title = Inventory Cycle


### PR DESCRIPTION
Instead of blindly assuming inventory size based on game (which does not work when a mod modifies inventory size), ask Minetest itself. When inventory width is not specified by game (MTG), assume it to be 8. Inventory height is reliably determined by looking at list length. If the list length is not a multiple of inventory width, remaining items are left untouched, avoiding any breakage.

Confirmed to work with MTG and MCL2.